### PR TITLE
Allow more flexibility with the columns

### DIFF
--- a/src/auditz.js
+++ b/src/auditz.js
@@ -63,37 +63,37 @@ export default (Model, bootOptions = {}) => {
   Model.settings.validateUpsert = options.validateUpsert;
 
   if(options.createdAt !== false) {
-    if(typeof(properties[options.createdAt]) == 'undefined') {
+    if(typeof(properties[options.createdAt]) === 'undefined') {
       Model.defineProperty(options.createdAt, {type: Date, required: options.required, defaultFn: 'now'});
     }
   }
 
   if(options.updatedAt !== false) {
-    if(typeof(properties[options.updatedAt]) == 'undefined') {
+    if(typeof(properties[options.updatedAt]) === 'undefined') {
       Model.defineProperty(options.updatedAt, {type: Date, required: options.required});
     }
   }
 
   if(options.deletedAt !== false) {
-    if(typeof(properties[options.deletedAt]) == 'undefined') {
+    if(typeof(properties[options.deletedAt]) === 'undefined') {
       Model.defineProperty(options.deletedAt, {type: Date, required: false});
     }
   }
 
   if(options.createdBy !== false) {
-    if(typeof(properties[options.createdBy]) == 'undefined') {
+    if(typeof(properties[options.createdBy]) === 'undefined') {
       Model.defineProperty(options.createdBy, {type: Number, required: false});
     }
   }
 
   if(options.updatedBy !== false) {
-    if(typeof(properties[options.updatedBy]) == 'undefined') {
+    if(typeof(properties[options.updatedBy]) === 'undefined') {
       Model.defineProperty(options.updatedBy, {type: Number, required: false});
     }
   }
 
   if(options.deletedBy !== false) {
-    if(typeof(properties[options.deletedBy]) == 'undefined') {
+    if(typeof(properties[options.deletedBy]) === 'undefined') {
       Model.defineProperty(options.deletedBy, {type: Number, required: false});
     }
   }

--- a/src/auditz.js
+++ b/src/auditz.js
@@ -62,13 +62,41 @@ export default (Model, bootOptions = {}) => {
 
   Model.settings.validateUpsert = options.validateUpsert;
 
-  Model.defineProperty(options.createdAt, {type: Date, required: options.required, defaultFn: 'now'});
-  Model.defineProperty(options.updatedAt, {type: Date, required: options.required});
-  Model.defineProperty(options.deletedAt, {type: Date, required: false});
+  if(options.createdAt !== false) {
+    if(typeof(properties[options.createdAt]) == 'undefined') {
+      Model.defineProperty(options.createdAt, {type: Date, required: options.required, defaultFn: 'now'});
+    }
+  }
 
-  Model.defineProperty(options.createdBy, {type: Number, required: false});
-  Model.defineProperty(options.updatedBy, {type: Number, required: false});
-  Model.defineProperty(options.deletedBy, {type: Number, required: false});
+  if(options.updatedAt !== false) {
+    if(typeof(properties[options.updatedAt]) == 'undefined') {
+      Model.defineProperty(options.updatedAt, {type: Date, required: options.required});
+    }
+  }
+
+  if(options.deletedAt !== false) {
+    if(typeof(properties[options.deletedAt]) == 'undefined') {
+      Model.defineProperty(options.deletedAt, {type: Date, required: false});
+    }
+  }
+
+  if(options.createdBy !== false) {
+    if(typeof(properties[options.createdBy]) == 'undefined') {
+      Model.defineProperty(options.createdBy, {type: Number, required: false});
+    }
+  }
+
+  if(options.updatedBy !== false) {
+    if(typeof(properties[options.updatedBy]) == 'undefined') {
+      Model.defineProperty(options.updatedBy, {type: Number, required: false});
+    }
+  }
+
+  if(options.deletedBy !== false) {
+    if(typeof(properties[options.deletedBy]) == 'undefined') {
+      Model.defineProperty(options.deletedBy, {type: Number, required: false});
+    }
+  }
 
   Model.observe('after save', (ctx, next) => {
     if (!options.revisions) {


### PR DESCRIPTION
Have the system check to see if they're defined, i'm mainly running into an issue where the postgres connector lowercases the names of the columns unless you specify them a certain way, and right now i don't use createdBy, updatedBy and deletedBy however i will likely use them in the future, but this allows them to be disabled by doing "createdBy": false in the model definition.